### PR TITLE
Updated monitoring-stack

### DIFF
--- a/playbooks/add-ons.yaml
+++ b/playbooks/add-ons.yaml
@@ -204,7 +204,7 @@
          when: helm_repo_add.rc == 0
 
        - name: Install Prometheus
-         shell: "helm install --version {{ prometheus_stack }} prometheus-community/kube-prometheus-stack --create-namespace --namespace monitoring --generate-name --values  {{ ansible_user_dir }}/kube-prometheus-stack.values"
+         shell: "helm install kube-prometheus-stack --version {{ prometheus_stack }} prometheus-community/kube-prometheus-stack --create-namespace --namespace monitoring --values  {{ ansible_user_dir }}/kube-prometheus-stack.values"
          when: helm_repo_add.rc == 0
 
        - name: Install Grafana Operator

--- a/playbooks/add-ons.yaml
+++ b/playbooks/add-ons.yaml
@@ -204,8 +204,11 @@
          when: helm_repo_add.rc == 0
 
        - name: Install Prometheus
-         shell: "helm install --version {{ prometheus_stack }} prometheus prometheus-community/prometheus --create-namespace --namespace monitoring"
+         shell: "helm install --version {{ prometheus_stack }} prometheus-community/kube-prometheus-stack --create-namespace --namespace monitoring --generate-name --values  {{ ansible_user_dir }}/kube-prometheus-stack.values"
          when: helm_repo_add.rc == 0
+
+       - name: Install Grafana Operator
+         shell: "helm upgrade -i grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version {{ grafana_operator }} -n monitoring"
 
        - name: Apply Grafana configuration
          shell: kubectl apply -f {{ ansible_user_dir }}/grafana.yaml -n monitoring

--- a/playbooks/add-ons.yaml
+++ b/playbooks/add-ons.yaml
@@ -215,7 +215,7 @@
          shell: kubectl apply -f {{ ansible_user_dir }}/grafana.yaml -n monitoring
 
        - name: Install Prometheus Adapter
-         shell: "helm install --version {{ prometheus_adapter }} prometheus-adapter prometheus-community/prometheus-adapter --namespace monitoring --set prometheus.url=http://prometheus-server,prometheus.port=80"
+         shell: "helm install --version {{ prometheus_adapter }} prometheus-adapter prometheus-community/prometheus-adapter --namespace monitoring --set prometheus.url=http://kube-prometheus-stack-prometheus.monitoring,prometheus.port=9090"
          when: helm_repo_add.rc == 0
 
        - name: Apply Metrics Server configuration

--- a/playbooks/add-ons.yaml
+++ b/playbooks/add-ons.yaml
@@ -83,6 +83,7 @@
        dest: "{{ ansible_user_dir }}/"
      with_fileglob:
        - "{{lookup('pipe', 'pwd')}}/files/grafana.yaml"
+       - "{{lookup('pipe', 'pwd')}}/files/kube-prometheus-stack.values"
        - "{{lookup('pipe', 'pwd')}}/files/fluent-values.yaml"
 
    - name: Install Kserve on Kubernetes

--- a/playbooks/cns_values.yaml
+++ b/playbooks/cns_values.yaml
@@ -2,8 +2,8 @@ cns_version: 13.2
 
 ## MicroK8s cluster
 microk8s: no
-## Kubernetes Install with Kubeadm 
-install_k8s: yes 
+## Kubernetes Install with Kubeadm
+install_k8s: yes
 
 ## Components Versions
 # Container Runtime options are containerd, cri-o, cri-dockerd
@@ -26,8 +26,9 @@ local_path_provisioner: "0.0.30"
 nfs_provisioner: "4.0.18"
 metallb_version: "0.14.8"
 kserve_version: "0.14"
-prometheus_stack: "25.27.0"
+prometheus_stack: "67.5.0"
 prometheus_adapter: "4.11.0"
+grafana_operator: "v5.15.1"
 elastic_stack: "8.15.3"
 lws_version: "0.4.0"
 
@@ -83,7 +84,7 @@ k8s_gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.ke
 k8s_apt_ring: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
 k8s_registry: "registry.k8s.io"
 
-# Install NVIDIA NIM Operator 
+# Install NVIDIA NIM Operator
 enable_nim_operator: no
 
 # LeaderWorkerSet https://github.com/kubernetes-sigs/lws/tree/main
@@ -106,7 +107,7 @@ loadbalancer_ip: ""
 ## Cloud Native Stack Validation
 cns_validation: no
 
-# BMC Details for Confidential Computing 
+# BMC Details for Confidential Computing
 bmc_ip:
 bmc_username:
 bmc_password:
@@ -119,7 +120,7 @@ aws_gpu_instance_type: g4dn.2xlarge
 
 ## Google Cloud GKE Values
 #https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
-gke_project_id: 
+gke_project_id:
 #https://cloud.google.com/compute/docs/regions-zones#available
 gke_region: us-west1
 gke_node_zones: ["us-west1-b"]

--- a/playbooks/cns_values_12.0.yaml
+++ b/playbooks/cns_values_12.0.yaml
@@ -2,8 +2,8 @@ cns_version: 12.0
 
 ## MicroK8s cluster
 microk8s: no
-## Kubernetes Install with Kubeadm 
-install_k8s: yes 
+## Kubernetes Install with Kubeadm
+install_k8s: yes
 
 ## Components Versions
 # Container Runtime options are containerd, cri-o, cri-dockerd
@@ -26,8 +26,9 @@ local_path_provisioner: "0.0.26"
 nfs_provisioner: "4.0.18"
 metallb_version: "0.14.5"
 kserve_version: "0.13"
-prometheus_stack: "25.27.0"
+prometheus_stack: "67.5.0"
 prometheus_adapter: "4.11.0"
+grafana_operator: "v5.15.1"
 elastic_stack: "8.14.1"
 lws_version: "0.4.0"
 
@@ -83,7 +84,7 @@ k8s_gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.ke
 k8s_apt_ring: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
 k8s_registry: "registry.k8s.io"
 
-# Install NVIDIA NIM Operator 
+# Install NVIDIA NIM Operator
 enable_nim_operator: no
 
 # LeaderWorkerSet https://github.com/kubernetes-sigs/lws/tree/main
@@ -106,7 +107,7 @@ loadbalancer_ip: ""
 ## Cloud Native Stack Validation
 cns_validation: no
 
-# BMC Details for Confidential Computing 
+# BMC Details for Confidential Computing
 bmc_ip:
 bmc_username:
 bmc_password:
@@ -119,7 +120,7 @@ aws_gpu_instance_type: g4dn.2xlarge
 
 ## Google Cloud GKE Values
 #https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
-gke_project_id: 
+gke_project_id:
 #https://cloud.google.com/compute/docs/regions-zones#available
 gke_region: us-west1
 gke_node_zones: ["us-west1-b"]

--- a/playbooks/cns_values_12.1.yaml
+++ b/playbooks/cns_values_12.1.yaml
@@ -2,8 +2,8 @@ cns_version: 12.1
 
 ## MicroK8s cluster
 microk8s: no
-## Kubernetes Install with Kubeadm 
-install_k8s: yes 
+## Kubernetes Install with Kubeadm
+install_k8s: yes
 
 ## Components Versions
 # Container Runtime options are containerd, cri-o, cri-dockerd
@@ -26,8 +26,9 @@ local_path_provisioner: "0.0.26"
 nfs_provisioner: "4.0.18"
 metallb_version: "0.14.5"
 kserve_version: "0.13"
-prometheus_stack: "25.27.0"
+prometheus_stack: "67.5.0"
 prometheus_adapter: "4.11.0"
+grafana_operator: "v5.15.1"
 elastic_stack: "8.14.1"
 lws_version: "0.4.0"
 
@@ -83,7 +84,7 @@ k8s_gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.ke
 k8s_apt_ring: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
 k8s_registry: "registry.k8s.io"
 
-# Install NVIDIA NIM Operator 
+# Install NVIDIA NIM Operator
 enable_nim_operator: no
 
 # LeaderWorkerSet https://github.com/kubernetes-sigs/lws/tree/main
@@ -106,7 +107,7 @@ loadbalancer_ip: ""
 ## Cloud Native Stack Validation
 cns_validation: no
 
-# BMC Details for Confidential Computing 
+# BMC Details for Confidential Computing
 bmc_ip:
 bmc_username:
 bmc_password:
@@ -119,7 +120,7 @@ aws_gpu_instance_type: g4dn.2xlarge
 
 ## Google Cloud GKE Values
 #https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
-gke_project_id: 
+gke_project_id:
 #https://cloud.google.com/compute/docs/regions-zones#available
 gke_region: us-west1
 gke_node_zones: ["us-west1-b"]

--- a/playbooks/cns_values_12.2.yaml
+++ b/playbooks/cns_values_12.2.yaml
@@ -2,8 +2,8 @@ cns_version: 12.2
 
 ## MicroK8s cluster
 microk8s: no
-## Kubernetes Install with Kubeadm 
-install_k8s: yes 
+## Kubernetes Install with Kubeadm
+install_k8s: yes
 
 ## Components Versions
 # Container Runtime options are containerd, cri-o, cri-dockerd
@@ -26,8 +26,9 @@ local_path_provisioner: "0.0.26"
 nfs_provisioner: "4.0.18"
 metallb_version: "0.14.5"
 kserve_version: "0.13"
-prometheus_stack: "25.27.0"
+prometheus_stack: "67.5.0"
 prometheus_adapter: "4.11.0"
+grafana_operator: "v5.15.1"
 elastic_stack: "8.14.1"
 lws_version: "0.4.0"
 
@@ -83,7 +84,7 @@ k8s_gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.ke
 k8s_apt_ring: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
 k8s_registry: "registry.k8s.io"
 
-# Install NVIDIA NIM Operator 
+# Install NVIDIA NIM Operator
 enable_nim_operator: no
 
 # LeaderWorkerSet https://github.com/kubernetes-sigs/lws/tree/main
@@ -106,7 +107,7 @@ loadbalancer_ip: ""
 ## Cloud Native Stack Validation
 cns_validation: no
 
-# BMC Details for Confidential Computing 
+# BMC Details for Confidential Computing
 bmc_ip:
 bmc_username:
 bmc_password:
@@ -119,7 +120,7 @@ aws_gpu_instance_type: g4dn.2xlarge
 
 ## Google Cloud GKE Values
 #https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
-gke_project_id: 
+gke_project_id:
 #https://cloud.google.com/compute/docs/regions-zones#available
 gke_region: us-west1
 gke_node_zones: ["us-west1-b"]

--- a/playbooks/cns_values_12.3.yaml
+++ b/playbooks/cns_values_12.3.yaml
@@ -2,8 +2,8 @@ cns_version: 12.3
 
 ## MicroK8s cluster
 microk8s: no
-## Kubernetes Install with Kubeadm 
-install_k8s: yes 
+## Kubernetes Install with Kubeadm
+install_k8s: yes
 
 ## Components Versions
 # Container Runtime options are containerd, cri-o, cri-dockerd
@@ -26,8 +26,9 @@ local_path_provisioner: "0.0.30"
 nfs_provisioner: "4.0.18"
 metallb_version: "0.14.8"
 kserve_version: "0.14"
-prometheus_stack: "25.27.0"
+prometheus_stack: "67.5.0"
 prometheus_adapter: "4.11.0"
+grafana_operator: "v5.15.1"
 elastic_stack: "8.15.3"
 lws_version: "0.4.0"
 
@@ -83,7 +84,7 @@ k8s_gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.ke
 k8s_apt_ring: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
 k8s_registry: "registry.k8s.io"
 
-# Install NVIDIA NIM Operator 
+# Install NVIDIA NIM Operator
 enable_nim_operator: no
 
 # LeaderWorkerSet https://github.com/kubernetes-sigs/lws/tree/main
@@ -106,7 +107,7 @@ loadbalancer_ip: ""
 ## Cloud Native Stack Validation
 cns_validation: no
 
-# BMC Details for Confidential Computing 
+# BMC Details for Confidential Computing
 bmc_ip:
 bmc_username:
 bmc_password:
@@ -119,7 +120,7 @@ aws_gpu_instance_type: g4dn.2xlarge
 
 ## Google Cloud GKE Values
 #https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
-gke_project_id: 
+gke_project_id:
 #https://cloud.google.com/compute/docs/regions-zones#available
 gke_region: us-west1
 gke_node_zones: ["us-west1-b"]

--- a/playbooks/cns_values_13.0.yaml
+++ b/playbooks/cns_values_13.0.yaml
@@ -2,8 +2,8 @@ cns_version: 13.0
 
 ## MicroK8s cluster
 microk8s: no
-## Kubernetes Install with Kubeadm 
-install_k8s: yes 
+## Kubernetes Install with Kubeadm
+install_k8s: yes
 
 ## Components Versions
 # Container Runtime options are containerd, cri-o, cri-dockerd
@@ -26,8 +26,9 @@ local_path_provisioner: "0.0.26"
 nfs_provisioner: "4.0.18"
 metallb_version: "0.14.5"
 kserve_version: "0.13"
-prometheus_stack: "25.27.0"
+prometheus_stack: "67.5.0"
 prometheus_adapter: "4.11.0"
+grafana_operator: "v5.15.1"
 elastic_stack: "8.14.1"
 lws_version: "0.4.0"
 
@@ -83,7 +84,7 @@ k8s_gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.ke
 k8s_apt_ring: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
 k8s_registry: "registry.k8s.io"
 
-# Install NVIDIA NIM Operator 
+# Install NVIDIA NIM Operator
 enable_nim_operator: no
 
 # LeaderWorkerSet https://github.com/kubernetes-sigs/lws/tree/main
@@ -106,7 +107,7 @@ loadbalancer_ip: ""
 ## Cloud Native Stack Validation
 cns_validation: no
 
-# BMC Details for Confidential Computing 
+# BMC Details for Confidential Computing
 bmc_ip:
 bmc_username:
 bmc_password:
@@ -119,7 +120,7 @@ aws_gpu_instance_type: g4dn.2xlarge
 
 ## Google Cloud GKE Values
 #https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
-gke_project_id: 
+gke_project_id:
 #https://cloud.google.com/compute/docs/regions-zones#available
 gke_region: us-west1
 gke_node_zones: ["us-west1-b"]

--- a/playbooks/cns_values_13.1.yaml
+++ b/playbooks/cns_values_13.1.yaml
@@ -2,8 +2,8 @@ cns_version: 13.1
 
 ## MicroK8s cluster
 microk8s: no
-## Kubernetes Install with Kubeadm 
-install_k8s: yes 
+## Kubernetes Install with Kubeadm
+install_k8s: yes
 
 ## Components Versions
 # Container Runtime options are containerd, cri-o, cri-dockerd
@@ -26,8 +26,9 @@ local_path_provisioner: "0.0.26"
 nfs_provisioner: "4.0.18"
 metallb_version: "0.14.5"
 kserve_version: "0.13"
-prometheus_stack: "25.27.0"
+prometheus_stack: "67.5.0"
 prometheus_adapter: "4.11.0"
+grafana_operator: "v5.15.1"
 elastic_stack: "8.14.1"
 lws_version: "0.4.0"
 
@@ -83,7 +84,7 @@ k8s_gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.ke
 k8s_apt_ring: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
 k8s_registry: "registry.k8s.io"
 
-# Install NVIDIA NIM Operator 
+# Install NVIDIA NIM Operator
 enable_nim_operator: no
 
 # LeaderWorkerSet https://github.com/kubernetes-sigs/lws/tree/main
@@ -106,7 +107,7 @@ loadbalancer_ip: ""
 ## Cloud Native Stack Validation
 cns_validation: no
 
-# BMC Details for Confidential Computing 
+# BMC Details for Confidential Computing
 bmc_ip:
 bmc_username:
 bmc_password:
@@ -119,7 +120,7 @@ aws_gpu_instance_type: g4dn.2xlarge
 
 ## Google Cloud GKE Values
 #https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
-gke_project_id: 
+gke_project_id:
 #https://cloud.google.com/compute/docs/regions-zones#available
 gke_region: us-west1
 gke_node_zones: ["us-west1-b"]

--- a/playbooks/cns_values_13.2.yaml
+++ b/playbooks/cns_values_13.2.yaml
@@ -2,8 +2,8 @@ cns_version: 13.2
 
 ## MicroK8s cluster
 microk8s: no
-## Kubernetes Install with Kubeadm 
-install_k8s: yes 
+## Kubernetes Install with Kubeadm
+install_k8s: yes
 
 ## Components Versions
 # Container Runtime options are containerd, cri-o, cri-dockerd
@@ -26,8 +26,9 @@ local_path_provisioner: "0.0.30"
 nfs_provisioner: "4.0.18"
 metallb_version: "0.14.8"
 kserve_version: "0.14"
-prometheus_stack: "25.27.0"
+prometheus_stack: "67.5.0"
 prometheus_adapter: "4.11.0"
+grafana_operator: "v5.15.1"
 elastic_stack: "8.15.3"
 lws_version: "0.4.0"
 
@@ -83,7 +84,7 @@ k8s_gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.ke
 k8s_apt_ring: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
 k8s_registry: "registry.k8s.io"
 
-# Install NVIDIA NIM Operator 
+# Install NVIDIA NIM Operator
 enable_nim_operator: no
 
 # LeaderWorkerSet https://github.com/kubernetes-sigs/lws/tree/main
@@ -106,7 +107,7 @@ loadbalancer_ip: ""
 ## Cloud Native Stack Validation
 cns_validation: no
 
-# BMC Details for Confidential Computing 
+# BMC Details for Confidential Computing
 bmc_ip:
 bmc_username:
 bmc_password:
@@ -119,7 +120,7 @@ aws_gpu_instance_type: g4dn.2xlarge
 
 ## Google Cloud GKE Values
 #https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
-gke_project_id: 
+gke_project_id:
 #https://cloud.google.com/compute/docs/regions-zones#available
 gke_region: us-west1
 gke_node_zones: ["us-west1-b"]

--- a/playbooks/cns_values_14.0.yaml
+++ b/playbooks/cns_values_14.0.yaml
@@ -2,8 +2,8 @@ cns_version: 14.0
 
 ## MicroK8s cluster
 microk8s: no
-## Kubernetes Install with Kubeadm 
-install_k8s: yes 
+## Kubernetes Install with Kubeadm
+install_k8s: yes
 
 ## Components Versions
 # Container Runtime options are containerd, cri-o, cri-dockerd
@@ -26,8 +26,9 @@ local_path_provisioner: "0.0.30"
 nfs_provisioner: "4.0.18"
 metallb_version: "0.14.8"
 kserve_version: "0.14"
-prometheus_stack: "25.27.0"
+prometheus_stack: "67.5.0"
 prometheus_adapter: "4.11.0"
+grafana_operator: "v5.15.1"
 elastic_stack: "8.15.3"
 lws_version: "0.4.0"
 
@@ -83,7 +84,7 @@ k8s_gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.31/rpm/repodata/repomd.xml.ke
 k8s_apt_ring: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
 k8s_registry: "registry.k8s.io"
 
-# Install NVIDIA NIM Operator 
+# Install NVIDIA NIM Operator
 enable_nim_operator: no
 
 # LeaderWorkerSet https://github.com/kubernetes-sigs/lws/tree/main
@@ -106,7 +107,7 @@ loadbalancer_ip: ""
 ## Cloud Native Stack Validation
 cns_validation: no
 
-# BMC Details for Confidential Computing 
+# BMC Details for Confidential Computing
 bmc_ip:
 bmc_username:
 bmc_password:
@@ -119,7 +120,7 @@ aws_gpu_instance_type: g4dn.2xlarge
 
 ## Google Cloud GKE Values
 #https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
-gke_project_id: 
+gke_project_id:
 #https://cloud.google.com/compute/docs/regions-zones#available
 gke_region: us-west1
 gke_node_zones: ["us-west1-b"]

--- a/playbooks/files/grafana.yaml
+++ b/playbooks/files/grafana.yaml
@@ -1,94 +1,82 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  annotations:
-    meta.helm.sh/release-name: prometheus
-    meta.helm.sh/release-namespace: monitoring
-  labels:
-    app.kubernetes.io/instance: prometheus
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.2.0
-    helm.sh/chart: grafana-8.5.1
-  name: prometheus-grafana-clusterrolebinding
-
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: prometheus-grafana-clusterrole
-subjects:
-- kind: ServiceAccount
-  name: prometheus-grafana
-  namespace: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    meta.helm.sh/release-name: prometheus
-    meta.helm.sh/release-namespace: monitoring
-  labels:
-    app.kubernetes.io/instance: prometheus
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.2.0
-    helm.sh/chart: grafana-8.5.1
-  name: prometheus-grafana-clusterrole
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - secrets
-  verbs:
-  - get
-  - watch
-  - list
----
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  annotations:
-    meta.helm.sh/release-name: prometheus
-    meta.helm.sh/release-namespace: monitoring
-  labels:
-    app.kubernetes.io/instance: prometheus
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.2.0
-    helm.sh/chart: grafana-8.5.1
-  name: prometheus-grafana
-  namespace: monitoring
----
-apiVersion: v1
-data:
-  admin-password: Y25zLXN0YWNr
-  admin-user: YWRtaW4=
-  ldap-toml: ""
 kind: Secret
+apiVersion: v1
 metadata:
-  annotations:
-    meta.helm.sh/release-name: prometheus
-    meta.helm.sh/release-namespace: monitoring
-  labels:
-    app.kubernetes.io/instance: prometheus
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.2.0
-    helm.sh/chart: grafana-8.5.1
-  name: prometheus-grafana
-  namespace: monitoring
+  name: credentials
+data:
+  GF_SECURITY_ADMIN_PASSWORD: Y25zLXN0YWNr
+  GF_SECURITY_ADMIN_USER: YWRtaW4=
 type: Opaque
 ---
-apiVersion: v1
-kind: ConfigMap
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
 metadata:
+  name: grafana
   labels:
-    grafana_dashboard: "1"
-  name: nvidia-dcgm
-data:
-  dcgm.json: |-
+    dashboards: "grafana"
+    folders: "grafana"
+spec:
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: grafana
+              env:
+                - name: GF_SECURITY_ADMIN_USER
+                  valueFrom:
+                    secretKeyRef:
+                      key: GF_SECURITY_ADMIN_USER
+                      name: credentials
+                - name: GF_SECURITY_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: GF_SECURITY_ADMIN_PASSWORD
+                      name: credentials
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+  service:
+    spec:
+      type: NodePort
+      ports:
+        - name: grafana
+          port: 3000
+          nodePort: 32222
+  version: 11.2.0
+
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: grafana-ds
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  datasource:
+    name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://kube-prometheus-stack-1735-prometheus.monitoring.svc.cluster.local:9090
+    isDefault: true
+    jsonData:
+      "tlsSkipVerify": true
+      "timeInterval": "5s"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: gpu-dashboard
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 5s
+  json: |
     {
       "__inputs": [
         {
@@ -901,363 +889,3 @@ data:
       },
       "version": 1
     }
----
-apiVersion: v1
-data:
-  provider.yaml: |-
-    apiVersion: 1
-    providers:
-      - name: 'sidecarProvider'
-        orgId: 1
-        folder: ''
-        folderUid: ''
-        type: file
-        disableDeletion: false
-        allowUiUpdates: false
-        updateIntervalSeconds: 30
-        options:
-          foldersFromFilesStructure: false
-          path: /tmp/dashboards
-kind: ConfigMap
-metadata:
-  annotations:
-    meta.helm.sh/release-name: prometheus
-    meta.helm.sh/release-namespace: monitoring
-  labels:
-    app.kubernetes.io/instance: prometheus
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.2.0
-    helm.sh/chart: grafana-8.5.1
-  name: prometheus-grafana-config-dashboards
-  namespace: monitoring
----
-apiVersion: v1
-data:
-  grafana.ini: |
-    [analytics]
-    check_for_updates = true
-    [grafana_net]
-    url = https://grafana.net
-    [log]
-    mode = console
-    [paths]
-    data = /var/lib/grafana/
-    logs = /var/log/grafana
-    plugins = /var/lib/grafana/plugins
-    provisioning = /etc/grafana/provisioning
-    [server]
-    domain = ''
-kind: ConfigMap
-metadata:
-  annotations:
-    meta.helm.sh/release-name: prometheus
-    meta.helm.sh/release-namespace: monitoring
-  labels:
-    app.kubernetes.io/instance: prometheus
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.2.0
-    helm.sh/chart: grafana-8.5.1
-  name: prometheus-grafana
-  namespace: monitoring
----
-apiVersion: v1
-data:
-  datasource.yaml: |
-    apiVersion: 1
-    datasources:
-    - name: "Prometheus"
-      type: prometheus
-      uid: prometheus
-      url: http://prometheus-server.monitoring:80/
-      access: proxy
-      isDefault: true
-      jsonData:
-        httpMethod: POST
-        timeInterval: 30s
-    - name: "Alertmanager"
-      type: alertmanager
-      uid: alertmanager
-      url: http://prometheus-alertmanager.monitoring:9093/
-      access: proxy
-      jsonData:
-        handleGrafanaManagedAlerts: false
-        implementation: prometheus
-kind: ConfigMap
-metadata:
-  name: grafana-datasource
-  namespace: monitoring
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "2"
-    meta.helm.sh/release-name: prometheus
-    meta.helm.sh/release-namespace: monitoring
-  labels:
-    app.kubernetes.io/instance: prometheus
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.2.0
-    helm.sh/chart: grafana-8.5.1
-  name: prometheus-grafana
-  namespace: monitoring
-spec:
-  progressDeadlineSeconds: 600
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: prometheus
-      app.kubernetes.io/name: grafana
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-        checksum/config: 0e9cbd0ea8e24e32f7dfca5bab17a2ba05652642f0a09a4882833ae88e4cc4a3
-        checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
-        checksum/secret: 8170dabcb50811fec7fe472dd672d0f35c9c4d2ed3d5d1bc9b7114783a728286
-        kubectl.kubernetes.io/default-container: grafana
-      creationTimestamp: null
-      labels:
-        app.kubernetes.io/instance: prometheus
-        app.kubernetes.io/name: grafana
-    spec:
-      automountServiceAccountToken: true
-      containers:
-      - env:
-        - name: METHOD
-          value: WATCH
-        - name: LABEL
-          value: grafana_dashboard
-        - name: LABEL_VALUE
-          value: "1"
-        - name: FOLDER
-          value: /tmp/dashboards
-        - name: RESOURCE
-          value: both
-        - name: NAMESPACE
-          value: ALL
-        - name: REQ_USERNAME
-          valueFrom:
-            secretKeyRef:
-              key: admin-user
-              name: prometheus-grafana
-        - name: REQ_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: admin-password
-              name: prometheus-grafana
-        - name: REQ_URL
-          value: http://localhost:3000/api/admin/provisioning/dashboards/reload
-        - name: REQ_METHOD
-          value: POST
-        image: quay.io/kiwigrid/k8s-sidecar:1.27.4
-        imagePullPolicy: IfNotPresent
-        name: grafana-sc-dashboard
-        resources: {}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /tmp/dashboards
-          name: sc-dashboard-volume
-      - env:
-        - name: METHOD
-          value: WATCH
-        - name: LABEL
-          value: grafana_datasource
-        - name: LABEL_VALUE
-          value: "1"
-        - name: FOLDER
-          value: /etc/grafana/provisioning/datasources
-        - name: RESOURCE
-          value: both
-        - name: REQ_USERNAME
-          valueFrom:
-            secretKeyRef:
-              key: admin-user
-              name: prometheus-grafana
-        - name: REQ_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: admin-password
-              name: prometheus-grafana
-        - name: REQ_URL
-          value: http://localhost:3000/api/admin/provisioning/datasources/reload
-        - name: REQ_METHOD
-          value: POST
-        image: quay.io/kiwigrid/k8s-sidecar:1.27.4
-        imagePullPolicy: IfNotPresent
-        name: grafana-sc-datasources
-        resources: {}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /etc/grafana/provisioning/datasources
-          name: sc-datasources-volume
-      - env:
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: GF_SECURITY_ADMIN_USER
-          valueFrom:
-            secretKeyRef:
-              key: admin-user
-              name: prometheus-grafana
-        - name: GF_SECURITY_ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: admin-password
-              name: prometheus-grafana
-        - name: GF_PATHS_DATA
-          value: /var/lib/grafana/
-        - name: GF_PATHS_LOGS
-          value: /var/log/grafana
-        - name: GF_PATHS_PLUGINS
-          value: /var/lib/grafana/plugins
-        - name: GF_PATHS_PROVISIONING
-          value: /etc/grafana/provisioning
-        image: docker.io/grafana/grafana:11.2.0
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 10
-          httpGet:
-            path: /api/health
-            port: 3000
-            scheme: HTTP
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 30
-        name: grafana
-        ports:
-        - containerPort: 3000
-          name: grafana
-          protocol: TCP
-        - containerPort: 9094
-          name: gossip-tcp
-          protocol: TCP
-        - containerPort: 9094
-          name: gossip-udp
-          protocol: UDP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /api/health
-            port: 3000
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources: {}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /var/lib/grafana/dashboards/dcgm.json
-          name: nv-dashboard-volume
-          subPath: dcgm.json
-        - mountPath: /etc/grafana/grafana.ini
-          name: config
-          subPath: grafana.ini
-        - mountPath: /var/lib/grafana
-          name: storage
-        - mountPath: /tmp/dashboards
-          name: sc-dashboard-volume
-        - mountPath: /etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml
-          name: sc-dashboard-provider
-          subPath: provider.yaml
-        - mountPath: /etc/grafana/provisioning/datasources
-          name: sc-datasources-volume
-      dnsPolicy: ClusterFirst
-      enableServiceLinks: true
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext:
-        fsGroup: 472
-        runAsGroup: 472
-        runAsNonRoot: true
-        runAsUser: 472
-      serviceAccount: prometheus-grafana
-      serviceAccountName: prometheus-grafana
-      terminationGracePeriodSeconds: 30
-      volumes:
-      - configMap:
-          defaultMode: 420
-          name: nvidia-dcgm
-        name: nv-dashboard-volume
-      - configMap:
-          defaultMode: 420
-          name: prometheus-grafana
-        name: config
-      - emptyDir: {}
-        name: storage
-      - emptyDir: {}
-        name: sc-dashboard-volume
-      - configMap:
-          defaultMode: 420
-          name: prometheus-grafana-config-dashboards
-        name: sc-dashboard-provider
-      - configMap:
-          name: grafana-datasource
-        name: sc-datasources-volume
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    meta.helm.sh/release-name: prometheus
-    meta.helm.sh/release-namespace: monitoring
-  labels:
-    app.kubernetes.io/instance: prometheus
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.2.0
-    helm.sh/chart: grafana-8.5.1
-  name: prometheus-grafana
-  namespace: monitoring
-spec:
-  externalTrafficPolicy: Cluster
-  internalTrafficPolicy: Cluster
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
-  ports:
-  - name: http-web
-    nodePort: 32222
-    port: 80
-    protocol: TCP
-    targetPort: 3000
-  selector:
-    app.kubernetes.io/instance: prometheus
-    app.kubernetes.io/name: grafana
-  sessionAffinity: None
-  type: NodePort

--- a/playbooks/files/grafana.yaml
+++ b/playbooks/files/grafana.yaml
@@ -61,7 +61,7 @@ spec:
     type: prometheus
     uid: prometheus
     access: proxy
-    url: http://kube-prometheus-stack-1735-prometheus.monitoring.svc.cluster.local:9090
+    url: http://kube-prometheus-stack-prometheus.monitoring:9090
     isDefault: true
     jsonData:
       "tlsSkipVerify": true

--- a/playbooks/files/kube-prometheus-stack.values
+++ b/playbooks/files/kube-prometheus-stack.values
@@ -1,0 +1,7 @@
+grafana:
+  enabled: false
+prometheus:
+  service:
+    type: NodePort
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
**What this PR does / why we need it?**
Install the Prometheus Operator and Grafana Operator instead of a standalone Prometheus and Grafana instance.
The standalone instances does not include important CRDs like servicemonitor ( https://github.com/prometheus-community/helm-charts/issues/3010 ), that is needed to monitor user-defined applications without directly modifying the Prometheus configuration, also absence of these CRDs limits flexibility and stop us to migrate monitoring resources to production environment.

**Changes:**
1. Install Prometheus Operator (kube-prometheus stack) by keeping Grafana deployment set to false, as it installs standalone Grafana instance with it
This [PR #2172](https://github.com/prometheus-community/helm-charts/pull/2172) suggests including the Grafana Operator within the `kube-prometheus stack` rather than Grafana instance, but  the Prometheus community recommends disabling Grafana in the stack and installing Grafana Operator separately.
2. Install Grafana Operator following this doc [https://github.com/grafana/grafana-operator](url)