### PR TITLE
adds FQDN for better acces remote kubectl clients

### DIFF
--- a/playbooks/templates/kubeadm-init-config.template
+++ b/playbooks/templates/kubeadm-init-config.template
@@ -11,3 +11,4 @@ networking:
   podSubnet: "{{ subnet }}"
 kubernetesVersion: "v{{ k8s_version }}"
 imageRepository: "{{ k8s_registry }}"
+controlPlaneEndpoint: "{{ ansible_fqdn }}"


### PR DESCRIPTION
To be able to use kubectl from an external machine, I would like to propose to add the control plane endpoint.