### PR TITLE
25.4.0 - Fix GPU Operator install failure with RDMA and Host MOFED

### DIFF
--- a/playbooks/operators-install.yaml
+++ b/playbooks/operators-install.yaml
@@ -513,8 +513,8 @@
      until: install_gds_open_rm_gpu_operator is succeeded
 
    - name: Installing the GPU Operator with RDMA and Host MOFED on NVIDIA Cloud Native Stack
-     when: "confidential_computing == false and enable_gpu_operator == true and use_open_kernel_module == false and deploy_ofed == false and enable_mig == false and  enable_rdma == true and enable_vgpu == false and enable_gds == false and enable_secure_boot == false and cns_nvidia_driver == false and ngc_registry_password == ''"
-     shell:  helm install --version {{ gpu_operator_version }} --values {{ ansible_user_dir }}/values.yaml --create-namespace --namespace nvidia-gpu-operator --devel '{{ gpu_operator_helm_chart }}' --set driver.rdma.enabled=true,driver.rdma.useHostMofed=true,driver.version='{{ gpu_driver_version }}',driver.repository='{{ gpu_operator_driver_registry }}' --wait --generate-name
+     when: "confidential_computing == false and enable_gpu_operator == true and use_open_kernel_module == false and deploy_ofed == false and enable_mig == true and  enable_rdma == true and enable_vgpu == false and enable_gds == false and enable_secure_boot == false and cns_nvidia_driver == false and ngc_registry_password == ''"
+     shell:  helm install --version {{ gpu_operator_version }} --values {{ ansible_user_dir }}/values.yaml --create-namespace --namespace nvidia-gpu-operator --devel '{{ gpu_operator_helm_chart }}' --set driver.rdma.enabled=true,driver.rdma.useHostMofed=true,mig.strategy='{{ mig_strategy }}',driver.version='{{ gpu_driver_version }}',driver.repository='{{ gpu_operator_driver_registry }}' --wait --generate-name
      retries: 5
      delay: 5
      register: install_gpu_operator_rdma_host_mofed


### PR DESCRIPTION
**What this PR does / why we need it**
In `v25.4.0`, playbook is failing when installing the GPU Operator with RDMA and Host MOFED. I noticed there are two tasks for installing this ([491](https://github.com/NVIDIA/cloud-native-stack/blob/9a1ce3d12e64e4389d58af51375a8a8e09b6f4ef/playbooks/operators-install.yaml#L491) and [515](https://github.com/NVIDIA/cloud-native-stack/blob/9a1ce3d12e64e4389d58af51375a8a8e09b6f4ef/playbooks/operators-install.yaml#L515)) . Both tasks have the same `when` condition, with only difference being the `register` name. Because of this, both tasks run, causing Helm to install the same chart twice, which led to failure with the following error:
```
TASK [Installing the Open RM GPU Operator with Network Operator and RDMA and GDS on NVIDIA Cloud Native Stack] ***********************************************
skipping: [localhost]

TASK [Installing the GPU Operator with RDMA and Host MOFED on NVIDIA Cloud Native Stack] *********************************************************************
changed: [localhost]

TASK [Installing the Open RM GPU Operator with RDMA and Host MOFED on NVIDIA Cloud Native Stack] *************************************************************
skipping: [localhost]

TASK [Installing the GDS with Open RM GPU Operator on NVIDIA Cloud Native Stack] *****************************************************************************
skipping: [localhost]

TASK [Installing the GPU Operator with RDMA and Host MOFED on NVIDIA Cloud Native Stack] *********************************************************************
FAILED - RETRYING: [localhost]: Installing the GPU Operator with RDMA and Host MOFED on NVIDIA Cloud Native Stack (5 retries left).
FAILED - RETRYING: [localhost]: Installing the GPU Operator with RDMA and Host MOFED on NVIDIA Cloud Native Stack (4 retries left).
FAILED - RETRYING: [localhost]: Installing the GPU Operator with RDMA and Host MOFED on NVIDIA Cloud Native Stack (3 retries left).
FAILED - RETRYING: [localhost]: Installing the GPU Operator with RDMA and Host MOFED on NVIDIA Cloud Native Stack (2 retries left).
FAILED - RETRYING: [localhost]: Installing the GPU Operator with RDMA and Host MOFED on NVIDIA Cloud Native Stack (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 5, "changed": true, "cmd": "helm install --version 25.3.0 --values /home/kalpanas/values.yaml --create-namespace --namespace nvidia-gpu-operator --devel 'nvidia/gpu-operator' --set driver.rdma.enabled=true,driver.rdma.useHostMofed=true,driver.version='570.124.06',driver.repository='nvcr.io/nvidia' --wait --generate-name", "delta": "0:00:01.854793", "end": "2025-04-25 13:29:02.862414", "msg": "non-zero return code", "rc": 1, "start": "2025-04-25 13:29:01.007621", "stderr": "Error: INSTALLATION FAILED: Unable to continue with install: ServiceAccount \"node-feature-discovery\" in namespace \"nvidia-gpu-operator\" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key \"meta.helm.sh/release-name\" must equal \"gpu-operator-1745567941\": current value is \"gpu-operator-1745567868\"", "stderr_lines": ["Error: INSTALLATION FAILED: Unable to continue with install: ServiceAccount \"node-feature-discovery\" in namespace \"nvidia-gpu-operator\" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key \"meta.helm.sh/release-name\" must equal \"gpu-operator-1745567941\": current value is \"gpu-operator-1745567868\""], "stdout": "", "stdout_lines": []}

PLAY RECAP ***************************************************************************************************************************************************
localhost                  : ok=115  changed=80   unreachable=0    failed=1    skipped=228  rescued=0    ignored=0
```

**Changes:**
Based on the `register` names, I assume one task is meant to run when `enable_mig` is `true`, and the other when `enable_mig` is `false`. 
In this PR, I have updated the `when` condition and `helm install` command accordingly.