### PR TITLE
Gcc setup fixes

### DIFF
--- a/playbooks/prerequisites.yaml
+++ b/playbooks/prerequisites.yaml
@@ -137,7 +137,7 @@
       become: true
       block:
         - name: capture gcc expected version
-          shell: cat /proc/version | tr -d '(' | tr -d ')' | awk '{print $8}' | cut -d '.' -f 1
+          shell: cat /proc/version | cut -d '(' -f 4 | cut -d ')' -f 1 | cut -d ' ' -f 2 | cut -d '.' -f 1
           register: gcc_expected_version
 
         - name: install expected gcc version

--- a/playbooks/prerequisites.yaml
+++ b/playbooks/prerequisites.yaml
@@ -107,6 +107,30 @@
       register: add_rhel_repo
       until: add_rhel_repo is succeeded
 
+    - name: Install kubernetes components for Ubuntu on NVIDIA Cloud Native Stack
+      become: true
+      when: "ansible_distribution == 'Ubuntu'"
+      apt:
+        name: ['build-essential', 'net-tools', 'libseccomp2', 'apt-transport-https', 'curl', 'ca-certificates', 'gnupg-agent' ,'software-properties-common', 'kubelet={{ k8s_version }}-1.1', 'kubeadm={{ k8s_version }}-1.1', 'kubectl={{ k8s_version }}-1.1']
+        state: present
+        update_cache: true
+        allow_change_held_packages: yes
+        force: yes
+      retries: 5
+      delay: 5
+      register: install_k8s_ubuntu
+      until: install_k8s_ubuntu is succeeded
+
+    - name: Install kubernetes components for RedHat on NVIDIA Cloud Native Stack
+      become: true
+      when: "ansible_distribution == 'RedHat'"
+      yum:
+        name: ['net-tools', 'libseccomp', 'curl', 'ca-certificates', 'kubelet-{{ k8s_version }}', 'kubeadm-{{ k8s_version }}', 'kubectl-{{ k8s_version }}']
+        state: present
+      retries: 5
+      delay: 5
+      register: install_k8s_rhel
+      until: install_k8s_rhel is succeeded
 
     - name: check update GCC for build essentials
       when: "ansible_distribution == 'Ubuntu'"
@@ -152,31 +176,6 @@
               link: "{{ g_plus_plus_bin_path.stdout }}"
               path: "{{ g_plus_plus_expected_version_bin_path.stdout }}"
             state: auto
-
-    - name: Install kubernetes components for Ubuntu on NVIDIA Cloud Native Stack
-      become: true
-      when: "ansible_distribution == 'Ubuntu'"
-      apt:
-        name: ['build-essential', 'net-tools', 'libseccomp2', 'apt-transport-https', 'curl', 'ca-certificates', 'gnupg-agent' ,'software-properties-common', 'kubelet={{ k8s_version }}-1.1', 'kubeadm={{ k8s_version }}-1.1', 'kubectl={{ k8s_version }}-1.1']
-        state: present
-        update_cache: true
-        allow_change_held_packages: yes
-        force: yes
-      retries: 5
-      delay: 5
-      register: install_k8s_ubuntu
-      until: install_k8s_ubuntu is succeeded
-
-    - name: Install kubernetes components for RedHat on NVIDIA Cloud Native Stack
-      become: true
-      when: "ansible_distribution == 'RedHat'"
-      yum:
-        name: ['net-tools', 'libseccomp', 'curl', 'ca-certificates', 'kubelet-{{ k8s_version }}', 'kubeadm-{{ k8s_version }}', 'kubectl-{{ k8s_version }}']
-        state: present
-      retries: 5
-      delay: 5
-      register: install_k8s_rhel
-      until: install_k8s_rhel is succeeded
 
     - name: Hold the installed Packages
       become: true


### PR DESCRIPTION
This PR addresses 2 issues which were both related to GCC setup needed for driver install.

1. A change in the last version cause GCC setup to be run before build-essentials is installed. This caused the "capture gcc binary path" block under "check update GCC for build essentials" task to fail on hosts where GCC wasn't already present. Reordering the tasks so that build-essentials is installed prior to this ensures this no longer occurs.

2. The earlier expression to "capture gcc expected version" based on the version used to build the kernel on the host did not work on some hosts. Updated the expression to be more universally accepted.