### PR TITLE
fix: prevent losing SSH connection during CNS uninstall

### DIFF
--- a/playbooks/cns-uninstall.yaml
+++ b/playbooks/cns-uninstall.yaml
@@ -145,6 +145,16 @@
      failed_when: false
      no_log: True
 
+   - name: Reset iptables default policies to ACCEPT
+     ansible.builtin.shell: "{{ item }}"
+     become: true
+     with_items:
+       - iptables -P INPUT ACCEPT
+       - iptables -P FORWARD ACCEPT
+       - iptables -P OUTPUT ACCEPT
+     ignore_errors: yes
+     failed_when: false
+
    - name: IPTables Cleanup
      ignore_errors: yes
      failed_when: false


### PR DESCRIPTION
**What this PR does / why we need it?**

> **Issue:** While uninstalling CNS, system is going unreachable at this step:
> ```
> TASK [IPTables Cleanup] **************************************************************************************************************************************
> changed: [localhost] => (item=iptables -F)
> changed: [localhost] => (item=ip link delete cni0)
> changed: [localhost] => (item=ip link delete flannel.1)
> 
> TASK [Check docker is installed] *****************************************************************************************************************************
> 
> ```
> After rebooting the machine, everything returns to normal. The issue is that the user has to be physically present at their dev machine whenever it occurs to reboot the system
> 
> **Reason:** IPTables Cleanup task clearing the iptables rules, which can cause the system to become unreachable. As mentioned in this [doc](https://www.cyberciti.biz/tips/linux-iptables-how-to-flush-all-rules.html#:~:text=iptables%20%2DP%20INPUT%20ACCEPT%0Aiptables%20%2DP%20FORWARD%20ACCEPT%0Aiptables%20%2DP%20OUTPUT%20ACCEPT), safer approach is to accept all traffic first to avoid ssh lockdown

**Changes:** 
Added new task `Reset iptables default policies to ACCEPT` before the existing IPTables Cleanup task


